### PR TITLE
Remove dynamic resolver fallback

### DIFF
--- a/src/Sitemap/SitemapGenerator.php
+++ b/src/Sitemap/SitemapGenerator.php
@@ -18,15 +18,12 @@ use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 
 class SitemapGenerator
 {
-
-    private iterable $resolvers;
     private array $resolverIndex = [];
     public function __construct(
         private RouterInterface $router,
         #[TaggedIterator('sitemap.resolver')]
         iterable $resolvers = []
     ) {
-        $this->resolvers = $resolvers;
         foreach ($resolvers as $resolver) {
             $this->resolverIndex[$resolver::class] = $resolver;
         }
@@ -71,23 +68,6 @@ class SitemapGenerator
             return;
         }
 
-        $this->processDynamicRoute($routeName, $pathVariables, $sitemapAttr, $urls);
-    }
-
-    private function processDynamicRoute(
-        string $routeName,
-        array $pathVariables,
-        Sitemap $sitemapAttr,
-        array &$urls
-    ): void {
-        $resolvers = $this->resolvers;
-
-        foreach ($resolvers as $resolver) {
-            if ($resolver->supports($routeName, $pathVariables)) {
-                $this->processResolver($routeName, $pathVariables, $resolver, $sitemapAttr, $urls);
-                return;
-            }
-        }
     }
 
     private function processResolver(


### PR DESCRIPTION
## Summary
- delete unused resolver fallback loop in `processRoute`
- drop no-longer-used `resolvers` property

## Testing
- `composer validate --no-check-all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa169cdf8832f8be0dd26b1dfc504