### PR TITLE
Add sitemap grouping support

### DIFF
--- a/src/Controller/SitemapController.php
+++ b/src/Controller/SitemapController.php
@@ -20,9 +20,9 @@ class SitemapController extends AbstractController
         private readonly Environment      $twig
     ) {}
 
-    public function __invoke(): Response
+    public function __invoke(?string $group = null): Response
     {
-        $urls = $this->generator->generate();
+        $urls = $this->generator->generate($group);
 
         return new Response(
             $this->twig->render('@Sitemap/sitemap.xml.twig', ['urls' => $urls]),

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -25,6 +25,20 @@ class Configuration implements ConfigurationInterface
             ->values($this->changeFreqValues())
             ->defaultValue(null)
             ->end()
+            ->arrayNode('groups')
+                ->useAttributeAsKey('name')
+                ->arrayPrototype()
+                    ->children()
+                        ->scalarNode('path')->defaultNull()->end()
+                        ->scalarNode('priority')->defaultValue(null)->end()
+                        ->enumNode('changefreq')
+                            ->values($this->changeFreqValues())
+                            ->defaultValue(null)
+                        ->end()
+                        ->scalarNode('lastmod')->defaultNull()->end()
+                    ->end()
+                ->end()
+            ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/DependencyInjection/SitemapExtension.php
+++ b/src/DependencyInjection/SitemapExtension.php
@@ -29,5 +29,6 @@ class SitemapExtension extends Extension
 
         $container->setParameter('sitemap.default_priority', $config['default_priority']);
         $container->setParameter('sitemap.default_changefreq', $config['default_changefreq']);
+        $container->setParameter('sitemap.groups', $config['groups']);
     }
 }

--- a/src/Resources/config/routes/sitemap.yaml
+++ b/src/Resources/config/routes/sitemap.yaml
@@ -1,4 +1,3 @@
 sitemap:
-  path: /sitemap.xml
-  controller: jgniecki\SitemapBundle\Controller\SitemapController
-  methods: GET
+  resource: '.'
+  type: sitemap

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -17,6 +17,13 @@ services:
     arguments:
       - '@router'
       - !tagged_iterator sitemap.resolver
+      - '%sitemap.groups%'
+
+  jgniecki\SitemapBundle\Routing\SitemapRouteLoader:
+    arguments:
+      $groups: '%sitemap.groups%'
+    tags:
+      - { name: routing.loader }
 
   jgniecki\SitemapBundle\Controller\SitemapController:
     public: true

--- a/src/Routing/SitemapRouteLoader.php
+++ b/src/Routing/SitemapRouteLoader.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace jgniecki\SitemapBundle\Routing;
+
+use jgniecki\SitemapBundle\Controller\SitemapController;
+use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class SitemapRouteLoader extends Loader
+{
+    private bool $loaded = false;
+
+    public function __construct(private array $groups = [])
+    {
+    }
+
+    public function load(mixed $resource, ?string $type = null)
+    {
+        if ($this->loaded) {
+            throw new \RuntimeException('Do not add this loader twice');
+        }
+
+        $routes = new RouteCollection();
+
+        // Index route
+        $routes->add('sitemap', new Route('/sitemap.xml', [
+            '_controller' => SitemapController::class,
+            'group' => null,
+        ]));
+
+        foreach ($this->groups as $name => $config) {
+            $path = $config['path'] ?? ('/sitemap-' . $name . '.xml');
+            $routes->add('sitemap_' . $name, new Route($path, [
+                '_controller' => SitemapController::class,
+                'group' => $name,
+            ]));
+        }
+
+        $this->loaded = true;
+
+        return $routes;
+    }
+
+    public function supports(mixed $resource, ?string $type = null): bool
+    {
+        return 'sitemap' === $type;
+    }
+}

--- a/src/Sitemap/Attribute/Sitemap.php
+++ b/src/Sitemap/Attribute/Sitemap.php
@@ -19,13 +19,15 @@ class Sitemap
      * @param string|null $lastmod
      * @param $images array<{loc: string, title: string, caption: string}>
      * @param string|null $resolver
+     * @param string|null $group
      */
     public function __construct(
         public ?float $priority = null,
         public ?ChangeFreqEnum $changefreq = null,
         public ?string $lastmod = null,
         public array $images = [],
-        public ?string $resolver = null
+        public ?string $resolver = null,
+        public ?string $group = null
     ) {
     }
 }

--- a/src/Sitemap/SitemapGenerator.php
+++ b/src/Sitemap/SitemapGenerator.php
@@ -9,6 +9,7 @@
 namespace jgniecki\SitemapBundle\Sitemap;
 
 use jgniecki\SitemapBundle\Sitemap\Attribute\Sitemap;
+use jgniecki\SitemapBundle\Sitemap\Enum\ChangeFreqEnum;
 use jgniecki\SitemapBundle\Sitemap\Interface\RouteResolverInterface;
 use jgniecki\SitemapBundle\Sitemap\Interface\ImageProviderInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -22,22 +23,31 @@ class SitemapGenerator
     public function __construct(
         private RouterInterface $router,
         #[TaggedIterator('sitemap.resolver')]
-        iterable $resolvers = []
+        iterable $resolvers = [],
+        private array $groups = []
     ) {
         foreach ($resolvers as $resolver) {
             $this->resolverIndex[$resolver::class] = $resolver;
         }
     }
 
-    public function generate(): array
+    public function generate(?string $group = null): array
     {
         $urls = [];
+
+        if ($group === null) {
+            foreach ($this->groups as $name => $config) {
+                $url = $this->router->generate('sitemap_' . $name, [], UrlGeneratorInterface::ABSOLUTE_URL);
+                $sitemapAttr = $this->createSitemapFromConfig($config);
+                $urls[] = $this->createUrlData($url, $sitemapAttr);
+            }
+        }
 
         foreach ($this->router->getRouteCollection() as $routeName => $route) {
             $controller = $route->getDefault('_controller');
             $sitemapAttr = $this->getSitemapAttribute($route, $controller);
 
-            if ($sitemapAttr) {
+            if ($sitemapAttr && (($group === null && $sitemapAttr->group === null) || $sitemapAttr->group === $group)) {
                 $this->processRoute($routeName, $route, $sitemapAttr, $urls);
             }
         }
@@ -149,10 +159,28 @@ class SitemapGenerator
             $methodAttr?->changefreq ?? $classAttr?->changefreq,
             $methodAttr?->lastmod ?? $classAttr?->lastmod,
             array_merge($classAttr?->images ?? [], $methodAttr?->images ?? []),
-            $methodAttr?->resolver ?? $classAttr?->resolver
+            $methodAttr?->resolver ?? $classAttr?->resolver,
+            $methodAttr?->group ?? $classAttr?->group
         );
 
         return $mergedAttr;
+    }
+
+    private function createSitemapFromConfig(array $config): Sitemap
+    {
+        $changefreq = null;
+        if (isset($config['changefreq'])) {
+            $changefreq = ChangeFreqEnum::from($config['changefreq']);
+        }
+
+        return new Sitemap(
+            $config['priority'] ?? null,
+            $changefreq,
+            $config['lastmod'] ?? null,
+            [],
+            null,
+            null
+        );
     }
 
     private function getPathVariables(Route $route): array


### PR DESCRIPTION
## Summary
- allow grouping sitemap entries by adding `group` field to attribute
- generate sitemap index if no group is specified
- create dynamic routes for groups via `SitemapRouteLoader`
- expose new controller parameter to render group-specific sitemaps

## Testing
- `composer install --no-interaction`
- `find src -name '*.php' | xargs -n 1 php -l`
- `composer validate --strict`


------
https://chatgpt.com/codex/tasks/task_e_6872687b97f4832f8060b80f40bcaf88