### PR TITLE
Move default sitemap config into groups

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -25,15 +25,12 @@ class Configuration implements ConfigurationInterface
             ->values($this->changeFreqValues())
             ->defaultValue(null)
             ->end()
-            ->arrayNode('default')
-                ->addDefaultsIfNotSet()
-                ->children()
-                    ->scalarNode('path')->defaultValue('/sitemap.xml')->end()
-                    ->scalarNode('lastmod')->defaultNull()->end()
-                ->end()
-            ->end()
             ->arrayNode('groups')
                 ->useAttributeAsKey('name')
+                ->defaultValue(['default' => [
+                    'path' => '/sitemap.xml',
+                    'lastmod' => null,
+                ]])
                 ->arrayPrototype()
                     ->children()
                         ->scalarNode('path')->defaultNull()->end()

--- a/src/DependencyInjection/SitemapExtension.php
+++ b/src/DependencyInjection/SitemapExtension.php
@@ -29,7 +29,11 @@ class SitemapExtension extends Extension
 
         $container->setParameter('sitemap.default_priority', $config['default_priority']);
         $container->setParameter('sitemap.default_changefreq', $config['default_changefreq']);
-        $container->setParameter('sitemap.groups', $config['groups']);
-        $container->setParameter('sitemap.default', $config['default']);
+        $groups = $config['groups'];
+        $default = $groups['default'] ?? ['path' => '/sitemap.xml', 'lastmod' => null];
+        unset($groups['default']);
+
+        $container->setParameter('sitemap.groups', $groups);
+        $container->setParameter('sitemap.default', $default);
     }
 }


### PR DESCRIPTION
## Summary
- treat the default sitemap as a group
- pull default config from `groups.default` and remove from groups list

## Testing
- `find src -name '*.php' -print | xargs -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6873c83a7fec832f993e5564bd02f548