### PR TITLE
Fix null default changefreq

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -25,7 +25,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->enumNode('default_changefreq')
                     ->values($this->changeFreqValues())
-                    ->defaultValue(null)
+                    ->defaultNull()
                     ->end()
                 ->arrayNode('groups')
                     ->useAttributeAsKey('name')


### PR DESCRIPTION
## Summary
- allow null `default_changefreq` in configuration

## Testing
- `composer validate --no-check-all`
- `php -l src/DependencyInjection/Configuration.php`


------
https://chatgpt.com/codex/tasks/task_e_6873d35600d8832fb39ea07fede0b5c5