### PR TITLE
Add host-level sitemap path and warnings for default group

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,13 @@ sitemap:
     default_changefreq: null
     hosts:
         default:
+            path: '/sitemap.xml'
             groups:
                 default:
-                    path: '/sitemap-default.xml'
+                    path: null
                     lastmod: null
 #        main:
+#            path: '/sitemap.xml'
 #            host: 'example.(com|pl)'
 #            groups:
 #                default:
@@ -64,13 +66,14 @@ sitemap:
 #                    path: '/sitemap-blog.xml'
 ```
 
-Each host can override the path and last modification date for its sitemap groups.
+Each host can override the path for the sitemap index and the path and last modification date for its sitemap groups. When a host defines only the default group, the `sitemap.hosts.<alias>.groups.default.path` setting is ignored and a warning is triggered; use `sitemap.hosts.<alias>.path` instead.
 
 ### Accessing the sitemap
 
 The bundle registers routes for your sitemaps automatically. Visit
-`/sitemap.xml` to see the sitemap index when multiple groups are configured.
-The default group's sitemap for a host is available under the path defined in
+the path defined in `sitemap.hosts.<alias>.path` (default `/sitemap.xml`) to see
+the sitemap index when multiple groups are configured. The default group's
+sitemap for a host is available under the path defined in
 `sitemap.hosts.<alias>.groups.default.path`.
 
 ## License

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -32,9 +32,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue([
                         'default' => [
                             'host' => null,
+                            'path' => '/sitemap.xml',
                             'groups' => [
                                 'default' => [
-                                    'path' => '/sitemap-default.xml',
+                                    'path' => null,
                                     'lastmod' => null,
                                 ],
                             ],
@@ -43,11 +44,12 @@ class Configuration implements ConfigurationInterface
                     ->arrayPrototype()
                         ->children()
                             ->scalarNode('host')->defaultNull()->end()
+                            ->scalarNode('path')->defaultValue('/sitemap.xml')->end()
                             ->arrayNode('groups')
                                 ->useAttributeAsKey('name')
                                 ->defaultValue([
                                     'default' => [
-                                        'path' => '/sitemap-default.xml',
+                                        'path' => null,
                                         'lastmod' => null,
                                     ],
                                 ])

--- a/src/Resources/config/packages/sitemap.yaml
+++ b/src/Resources/config/packages/sitemap.yaml
@@ -8,7 +8,8 @@ sitemap:
     default_changefreq: null
     hosts:
         default:
+            path: '/sitemap.xml'
             groups:
                 default:
-                    path: '/sitemap-default.xml'
+                    path: null
                     lastmod: null

--- a/src/Routing/SitemapRouteLoader.php
+++ b/src/Routing/SitemapRouteLoader.php
@@ -45,12 +45,13 @@ class SitemapRouteLoader extends Loader
             $pattern = $hostConfig['host'] ?? null;
             $condition = $pattern ? "request.getHost() matches '/^" . $pattern . "$/'" : null;
             $groups = $hostConfig['groups'] ?? [];
-            $default = $groups['default'] ?? ['path' => '/sitemap-default.xml', 'lastmod' => null];
+            $default = $groups['default'] ?? ['path' => null, 'lastmod' => null];
             unset($groups['default']);
 
             $hasGroups = !empty($groups);
 
-            $routes->add('sitemap_' . $alias, new Route('/sitemap.xml', [
+            $path = $hostConfig['path'] ?? '/sitemap.xml';
+            $routes->add('sitemap_' . $alias, new Route($path, [
                 '_controller' => SitemapController::class,
                 'group' => null,
                 'index' => $hasGroups,
@@ -63,6 +64,15 @@ class SitemapRouteLoader extends Loader
                     'group' => null,
                     'index' => false,
                 ], [], [], '', [], [], $condition));
+            } elseif (!empty($default['path'])) {
+                @trigger_error(
+                    sprintf(
+                        'Configuration "sitemap.hosts.%s.groups.default.path" is ignored when no additional groups are defined; use "sitemap.hosts.%s.path" instead.',
+                        $alias,
+                        $alias
+                    ),
+                    E_USER_WARNING
+                );
             }
 
             foreach ($groups as $name => $config) {

--- a/src/Sitemap/SitemapGenerator.php
+++ b/src/Sitemap/SitemapGenerator.php
@@ -36,7 +36,7 @@ class SitemapGenerator
         [$alias, $hostConfig] = $this->resolveHost($host);
 
         $groups = $hostConfig['groups'] ?? [];
-        $default = $groups['default'] ?? ['path' => '/sitemap-default.xml', 'lastmod' => null];
+        $default = $groups['default'] ?? ['path' => null, 'lastmod' => null];
         unset($groups['default']);
 
         $urls = [];


### PR DESCRIPTION
## Summary
- allow defining `sitemap.hosts.<alias>.path` for per-host sitemap index
- log a warning when only the default group is configured and its path is set
- default the single group's path to `null` so unused configuration is ignored
- update docs and default config to show new host-level path and null group path

## Testing
- `php -l src/DependencyInjection/Configuration.php`
- `php -l src/Routing/SitemapRouteLoader.php`
- `php -l src/Sitemap/SitemapGenerator.php`
- `composer validate --strict` *(fails: description is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b9592e85f4832fbf0bdcd964975eda