### PR TITLE
Filter routes by host when generating sitemap

### DIFF
--- a/src/Sitemap/SitemapGenerator.php
+++ b/src/Sitemap/SitemapGenerator.php
@@ -56,6 +56,10 @@ class SitemapGenerator
         }
 
         foreach ($this->router->getRouteCollection() as $routeName => $route) {
+            if (!$this->isRouteForHost($route, $host)) {
+                continue;
+            }
+
             $controller = $route->getDefault('_controller');
             $sitemapAttr = $this->getSitemapAttribute($route, $controller);
 
@@ -205,6 +209,22 @@ class SitemapGenerator
             null,
             null
         );
+    }
+
+    private function isRouteForHost(Route $route, string $host): bool
+    {
+        if ($route->getHost() === '') {
+            return true;
+        }
+
+        $compiled = $route->compile();
+        $regex = $compiled->getHostRegex();
+
+        if ($regex !== null) {
+            return preg_match($regex, $host) === 1;
+        }
+
+        return strcasecmp($route->getHost(), $host) === 0;
     }
 
     private function getPathVariables(Route $route): array


### PR DESCRIPTION
## Summary
- ensure sitemap generator only includes routes for the current host
- add helper to match routes against host patterns

## Testing
- `composer test` (fails: Command "test" is not defined.)
- `./vendor/bin/phpunit` (fails: No such file or directory)
- `php -l src/Sitemap/SitemapGenerator.php`


------
https://chatgpt.com/codex/tasks/task_e_68b95e69ad50832f8025a00baeea3283